### PR TITLE
Add owner-only fs upload and mkdir endpoints

### DIFF
--- a/packages/server/src/api-filesystem-write.test.ts
+++ b/packages/server/src/api-filesystem-write.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createSession, createUser, openDb } from 'teepee-core';
+import { startServer } from './index.js';
+
+interface RequestResult {
+  status: number;
+  body: any;
+  headers: http.IncomingHttpHeaders;
+}
+
+function requestJson(
+  port: number,
+  method: string,
+  urlPath: string,
+  cookie?: string,
+  body?: object
+): Promise<RequestResult> {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: urlPath,
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(cookie ? { Cookie: cookie } : {}),
+          ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {}),
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => (raw += chunk));
+        res.on('end', () => {
+          let parsed;
+          try { parsed = JSON.parse(raw); } catch { parsed = raw; }
+          resolve({ status: res.statusCode || 0, body: parsed, headers: res.headers });
+        });
+      }
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+function requestUpload(
+  port: number,
+  urlPath: string,
+  cookie: string,
+  payload: Buffer
+): Promise<RequestResult> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: urlPath,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/octet-stream',
+          'Content-Length': payload.length,
+          Cookie: cookie,
+        },
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (chunk) => (raw += chunk));
+        res.on('end', () => {
+          let parsed;
+          try { parsed = JSON.parse(raw); } catch { parsed = raw; }
+          resolve({ status: res.statusCode || 0, body: parsed, headers: res.headers });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+function waitForServer(port: number): Promise<void> {
+  return new Promise((resolve) => {
+    const check = () => {
+      const req = http.request({ hostname: '127.0.0.1', port, path: '/auth/session', method: 'GET' }, () => resolve());
+      req.on('error', () => setTimeout(check, 50));
+      req.end();
+    };
+    check();
+  });
+}
+
+describe('filesystem write API (upload/mkdir)', () => {
+  let tmpDir: string;
+  let close: () => void;
+  let port: number;
+  let ownerCookie: string;
+  let observerCookie: string;
+
+  beforeAll(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'teepee-fs-write-'));
+    fs.mkdirSync(path.join(tmpDir, '.teepee'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'docs'), { recursive: true });
+
+    const configPath = path.join(tmpDir, '.teepee', 'config.yaml');
+    fs.writeFileSync(configPath, `
+version: 2
+mode: shared
+teepee:
+  name: fs-write-test
+providers:
+  echo:
+    command: "cat"
+agents:
+  architect:
+    provider: echo
+roles:
+  owner:
+    superuser: true
+    agents:
+      architect: trusted
+  observer:
+    capabilities:
+      - files.workspace.access
+    agents: {}
+`);
+
+    port = 38000 + Math.floor(Math.random() * 4000);
+    const result = startServer(configPath, port);
+    close = result.close;
+    await waitForServer(port);
+
+    const db = openDb(path.join(tmpDir, '.teepee', 'db.sqlite'));
+    ownerCookie = `teepee_session=${createSession(db, 'owner@localhost')}`;
+    createUser(db, 'observer@example.test', 'observer');
+    observerCookie = `teepee_session=${createSession(db, 'observer@example.test')}`;
+    db.close();
+  });
+
+  afterAll(() => {
+    close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('denies upload to non-owner users with 403', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=note.txt',
+      observerCookie,
+      Buffer.from('hello'),
+    );
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Insufficient permissions');
+    expect(fs.existsSync(path.join(tmpDir, 'docs', 'note.txt'))).toBe(false);
+  });
+
+  it('uploads a file into a workspace subdirectory for owner', async () => {
+    const payload = Buffer.from('hello upload\n');
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=note.txt',
+      ownerCookie,
+      payload,
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.path).toBe('docs/note.txt');
+    expect(res.body.size).toBe(payload.length);
+
+    const onDisk = fs.readFileSync(path.join(tmpDir, 'docs', 'note.txt'));
+    expect(onDisk.equals(payload)).toBe(true);
+  });
+
+  it('uploads at the workspace root when path is "." or empty', async () => {
+    const payload = Buffer.from('root level');
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=.&filename=root-note.txt',
+      ownerCookie,
+      payload,
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.path).toBe('root-note.txt');
+    expect(fs.readFileSync(path.join(tmpDir, 'root-note.txt'), 'utf-8')).toBe('root level');
+  });
+
+  it('rejects path-traversal filenames with 400', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=' + encodeURIComponent('../escape.txt'),
+      ownerCookie,
+      Buffer.from('nope'),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid filename');
+    expect(fs.existsSync(path.join(tmpDir, 'escape.txt'))).toBe(false);
+  });
+
+  it('rejects null-byte filenames with 400', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=' + encodeURIComponent('bad\u0000name.txt'),
+      ownerCookie,
+      Buffer.from('nope'),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Invalid filename');
+  });
+
+  it('rejects parent-path traversal via path query', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=' + encodeURIComponent('../') + '&filename=escape.txt',
+      ownerCookie,
+      Buffer.from('nope'),
+    );
+    expect(res.status).toBe(400);
+    expect(fs.existsSync(path.join(path.dirname(tmpDir), 'escape.txt'))).toBe(false);
+  });
+
+  it('returns 409 with suggestedName when file exists and on_conflict=fail', async () => {
+    const target = path.join(tmpDir, 'docs', 'dup.txt');
+    fs.writeFileSync(target, 'first');
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=dup.txt&on_conflict=fail',
+      ownerCookie,
+      Buffer.from('second'),
+    );
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('File already exists');
+    expect(res.body.suggestedName).toBe('dup (1).txt');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('first');
+  });
+
+  it('auto-renames when on_conflict=rename', async () => {
+    const target = path.join(tmpDir, 'docs', 'rename-me.txt');
+    fs.writeFileSync(target, 'original');
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=rename-me.txt&on_conflict=rename',
+      ownerCookie,
+      Buffer.from('new copy'),
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.renamed).toBe(true);
+    expect(res.body.name).toBe('rename-me (1).txt');
+    expect(fs.readFileSync(target, 'utf-8')).toBe('original');
+    expect(fs.readFileSync(path.join(tmpDir, 'docs', 'rename-me (1).txt'), 'utf-8')).toBe('new copy');
+  });
+
+  it('overwrites when on_conflict=overwrite', async () => {
+    const target = path.join(tmpDir, 'docs', 'overwrite.txt');
+    fs.writeFileSync(target, 'before');
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=overwrite.txt&on_conflict=overwrite',
+      ownerCookie,
+      Buffer.from('after'),
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.renamed).toBe(false);
+    expect(fs.readFileSync(target, 'utf-8')).toBe('after');
+  });
+
+  it('rejects on_conflict overwrite when target is a directory', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'docs', 'subdir'), { recursive: true });
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=subdir&on_conflict=overwrite',
+      ownerCookie,
+      Buffer.from('x'),
+    );
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 413 when upload exceeds the size cap', async () => {
+    const payload = Buffer.alloc(25 * 1024 * 1024 + 1, 0x41);
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=oversize.bin',
+      ownerCookie,
+      payload,
+    );
+    expect(res.status).toBe(413);
+    expect(res.body.error).toBe('Payload too large');
+    expect(fs.existsSync(path.join(tmpDir, 'docs', 'oversize.bin'))).toBe(false);
+    const leftovers = fs.readdirSync(path.join(tmpDir, 'docs'))
+      .filter((name) => name.startsWith('oversize.bin'));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('returns 400 when filename is missing', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs',
+      ownerCookie,
+      Buffer.from('x'),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('filename is required');
+  });
+
+  it('returns 400 when on_conflict is invalid', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=docs&filename=ok.txt&on_conflict=wat',
+      ownerCookie,
+      Buffer.from('x'),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when target directory does not exist', async () => {
+    const res = await requestUpload(
+      port,
+      '/api/fs/upload?root=workspace&path=nope-nope&filename=x.txt',
+      ownerCookie,
+      Buffer.from('x'),
+    );
+    expect([400, 403, 404]).toContain(res.status);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  // ── mkdir ──
+
+  it('denies mkdir to non-owner users with 403', async () => {
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', observerCookie, {
+      root: 'workspace', path: '.', name: 'new-folder',
+    });
+    expect(res.status).toBe(403);
+    expect(fs.existsSync(path.join(tmpDir, 'new-folder'))).toBe(false);
+  });
+
+  it('creates a new directory inside a workspace subfolder', async () => {
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', ownerCookie, {
+      root: 'workspace', path: 'docs', name: 'reports',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body.path).toBe('docs/reports');
+    expect(fs.statSync(path.join(tmpDir, 'docs', 'reports')).isDirectory()).toBe(true);
+  });
+
+  it('returns 409 when a directory with that name already exists', async () => {
+    fs.mkdirSync(path.join(tmpDir, 'docs', 'dup-dir'), { recursive: true });
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', ownerCookie, {
+      root: 'workspace', path: 'docs', name: 'dup-dir',
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('rejects mkdir with traversal name', async () => {
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', ownerCookie, {
+      root: 'workspace', path: 'docs', name: '../escape',
+    });
+    expect(res.status).toBe(400);
+    expect(fs.existsSync(path.join(tmpDir, 'escape'))).toBe(false);
+  });
+
+  it('rejects mkdir with empty name', async () => {
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', ownerCookie, {
+      root: 'workspace', path: 'docs', name: '',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects mkdir with missing root', async () => {
+    const res = await requestJson(port, 'POST', '/api/fs/mkdir', ownerCookie, {
+      path: 'docs', name: 'x',
+    } as any);
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/server/src/http/api/filesystem.ts
+++ b/packages/server/src/http/api/filesystem.ts
@@ -1,13 +1,20 @@
 import * as fs from 'fs';
+import * as nodePath from 'path';
+import * as crypto from 'crypto';
 import {
+  FileAccessError,
   findTopicByPath,
   listTopicArtifacts,
   listTopicChildren,
   resolveFileTarget,
 } from 'teepee-core';
+import { readJsonBody } from '../utils.js';
 import type { ApiRouteContext } from './context.js';
 
 const FILE_SELECTOR_LIMIT = 50;
+const UPLOAD_MAX_BYTES = 25 * 1024 * 1024;
+const MKDIR_NAME_MAX_LEN = 255;
+type ConflictPolicy = 'fail' | 'rename' | 'overwrite';
 
 interface FileSelectorEntry {
   name: string;
@@ -242,6 +249,264 @@ export function handleFilesystemRoutes(routeCtx: ApiRouteContext): boolean {
     return true;
   }
 
+  // ── Owner-only write endpoints ──
+
+  if (url.pathname === '/api/fs/upload' && req.method === 'POST') {
+    if (currentUser.role !== 'owner') {
+      json({ error: 'Insufficient permissions' }, 403);
+      return true;
+    }
+
+    const rootId = url.searchParams.get('root');
+    const dirParam = url.searchParams.get('path') ?? '.';
+    const filenameRaw = url.searchParams.get('filename');
+    const onConflictRaw = url.searchParams.get('on_conflict') ?? 'fail';
+
+    if (!rootId || typeof rootId !== 'string') {
+      json({ error: 'root is required' }, 400);
+      return true;
+    }
+    if (typeof dirParam !== 'string') {
+      json({ error: 'path is required' }, 400);
+      return true;
+    }
+    if (!filenameRaw || typeof filenameRaw !== 'string') {
+      json({ error: 'filename is required' }, 400);
+      return true;
+    }
+
+    const filename = sanitizeBasename(filenameRaw);
+    if (!filename) {
+      json({ error: 'Invalid filename' }, 400);
+      return true;
+    }
+    if (onConflictRaw !== 'fail' && onConflictRaw !== 'rename' && onConflictRaw !== 'overwrite') {
+      json({ error: 'on_conflict must be fail, rename, or overwrite' }, 400);
+      return true;
+    }
+    const onConflict = onConflictRaw as ConflictPolicy;
+
+    let parentTarget;
+    try {
+      parentTarget = resolveFileTarget(ctx.config, currentUser.role, rootId, dirParam || '.');
+    } catch (err: any) {
+      if (err instanceof FileAccessError) {
+        json({ error: err.message }, err.status);
+        return true;
+      }
+      json({ error: 'Failed to resolve target directory' }, 500);
+      return true;
+    }
+    let parentStat;
+    try {
+      parentStat = fs.statSync(parentTarget.absolutePath);
+    } catch {
+      json({ error: 'Target directory not found' }, 404);
+      return true;
+    }
+    if (!parentStat.isDirectory()) {
+      json({ error: 'Target path is not a directory' }, 400);
+      return true;
+    }
+
+    let finalName = filename;
+    let finalRelPath = joinRootRelative(parentTarget.relativePath, finalName);
+    let resolvedTarget;
+    try {
+      resolvedTarget = resolveFileTarget(ctx.config, currentUser.role, rootId, finalRelPath, { allowMissing: true });
+    } catch (err: any) {
+      if (err instanceof FileAccessError) {
+        json({ error: err.message }, err.status);
+        return true;
+      }
+      json({ error: 'Failed to resolve target file' }, 500);
+      return true;
+    }
+
+    if (fs.existsSync(resolvedTarget.absolutePath)) {
+      if (onConflict === 'fail') {
+        const suggested = suggestAvailableName(parentTarget.absolutePath, filename);
+        json({ error: 'File already exists', suggestedName: suggested }, 409);
+        return true;
+      }
+      if (onConflict === 'rename') {
+        finalName = suggestAvailableName(parentTarget.absolutePath, filename);
+        finalRelPath = joinRootRelative(parentTarget.relativePath, finalName);
+        try {
+          resolvedTarget = resolveFileTarget(ctx.config, currentUser.role, rootId, finalRelPath, { allowMissing: true });
+        } catch (err: any) {
+          if (err instanceof FileAccessError) {
+            json({ error: err.message }, err.status);
+            return true;
+          }
+          json({ error: 'Failed to resolve renamed target' }, 500);
+          return true;
+        }
+      } else {
+        const existingStat = fs.statSync(resolvedTarget.absolutePath);
+        if (!existingStat.isFile()) {
+          json({ error: 'Target exists and is not a regular file' }, 409);
+          return true;
+        }
+      }
+    }
+
+    const tmpPath = `${resolvedTarget.absolutePath}.partial.${crypto.randomBytes(8).toString('hex')}`;
+    const writeStream = fs.createWriteStream(tmpPath, { flags: 'wx' });
+    let totalBytes = 0;
+    let settled = false;
+    let endReceived = false;
+
+    const fail = (status: number, error: string) => {
+      if (settled) return;
+      settled = true;
+      req.removeAllListeners('data');
+      req.removeAllListeners('end');
+      req.removeAllListeners('error');
+      req.removeAllListeners('close');
+      writeStream.destroy();
+      fs.promises.unlink(tmpPath).catch(() => undefined);
+      try { req.resume(); } catch { /* noop */ }
+      json({ error }, status);
+    };
+
+    req.on('data', (chunk: Buffer) => {
+      if (settled) return;
+      totalBytes += chunk.length;
+      if (totalBytes > UPLOAD_MAX_BYTES) {
+        fail(413, 'Payload too large');
+        return;
+      }
+      if (!writeStream.write(chunk)) {
+        req.pause();
+        writeStream.once('drain', () => {
+          if (!settled) req.resume();
+        });
+      }
+    });
+    req.on('end', () => {
+      if (settled) return;
+      endReceived = true;
+      writeStream.end(() => {
+        if (settled) return;
+        try {
+          fs.renameSync(tmpPath, resolvedTarget.absolutePath);
+        } catch (err: any) {
+          settled = true;
+          fs.promises.unlink(tmpPath).catch(() => undefined);
+          json({ error: 'Failed to finalize upload' }, 500);
+          return;
+        }
+        settled = true;
+        try {
+          ctx.broadcastGlobal({
+            kind: 'fs:invalidate',
+            root: rootId,
+            path: parentTarget.relativePath === '.' ? '' : parentTarget.relativePath,
+          });
+        } catch { /* broadcasting must never break the response */ }
+        json({
+          ok: true,
+          root: rootId,
+          path: resolvedTarget.relativePath,
+          name: finalName,
+          size: totalBytes,
+          renamed: finalName !== filename,
+        }, 201);
+      });
+    });
+    req.on('error', () => fail(400, 'Failed to read request body'));
+    req.on('close', () => {
+      if (!settled && !endReceived) fail(400, 'Request body stream closed unexpectedly');
+    });
+    writeStream.on('error', () => fail(500, 'Failed to write upload'));
+
+    return true;
+  }
+
+  if (url.pathname === '/api/fs/mkdir' && req.method === 'POST') {
+    if (currentUser.role !== 'owner') {
+      json({ error: 'Insufficient permissions' }, 403);
+      return true;
+    }
+    void readJsonBody<{ root?: string; path?: string; name?: string }>(req).then((body) => {
+      if (!body.ok) {
+        json({ error: body.error }, body.status);
+        return;
+      }
+      const { root: rootId, path: dirParam, name: rawName } = body.value;
+      if (!rootId || typeof rootId !== 'string') {
+        json({ error: 'root is required' }, 400);
+        return;
+      }
+      const parentPath = typeof dirParam === 'string' && dirParam.length > 0 ? dirParam : '.';
+      if (!rawName || typeof rawName !== 'string') {
+        json({ error: 'name is required' }, 400);
+        return;
+      }
+      const name = sanitizeBasename(rawName);
+      if (!name) {
+        json({ error: 'Invalid name' }, 400);
+        return;
+      }
+
+      let parentTarget;
+      try {
+        parentTarget = resolveFileTarget(ctx.config, currentUser.role, rootId, parentPath);
+      } catch (err: any) {
+        if (err instanceof FileAccessError) {
+          json({ error: err.message }, err.status);
+          return;
+        }
+        json({ error: 'Failed to resolve target directory' }, 500);
+        return;
+      }
+      let parentStat;
+      try {
+        parentStat = fs.statSync(parentTarget.absolutePath);
+      } catch {
+        json({ error: 'Target directory not found' }, 404);
+        return;
+      }
+      if (!parentStat.isDirectory()) {
+        json({ error: 'Target path is not a directory' }, 400);
+        return;
+      }
+
+      const childRel = joinRootRelative(parentTarget.relativePath, name);
+      let resolvedChild;
+      try {
+        resolvedChild = resolveFileTarget(ctx.config, currentUser.role, rootId, childRel, { allowMissing: true });
+      } catch (err: any) {
+        if (err instanceof FileAccessError) {
+          json({ error: err.message }, err.status);
+          return;
+        }
+        json({ error: 'Failed to resolve new directory path' }, 500);
+        return;
+      }
+      if (fs.existsSync(resolvedChild.absolutePath)) {
+        json({ error: 'A file or directory with that name already exists' }, 409);
+        return;
+      }
+      try {
+        fs.mkdirSync(resolvedChild.absolutePath);
+      } catch (err: any) {
+        json({ error: 'Failed to create directory' }, 500);
+        return;
+      }
+      try {
+        ctx.broadcastGlobal({
+          kind: 'fs:invalidate',
+          root: rootId,
+          path: parentTarget.relativePath === '.' ? '' : parentTarget.relativePath,
+        });
+      } catch { /* broadcasting must never break the response */ }
+      json({ ok: true, root: rootId, path: resolvedChild.relativePath, name }, 201);
+    });
+    return true;
+  }
+
   if (url.pathname === '/api/workspace/file' && req.method === 'GET') {
     const filePath = url.searchParams.get('path');
     if (!filePath || typeof filePath !== 'string') {
@@ -264,4 +529,38 @@ export function handleFilesystemRoutes(routeCtx: ApiRouteContext): boolean {
   }
 
   return false;
+}
+
+function sanitizeBasename(raw: string): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.includes('\0')) return null;
+  if (trimmed.includes('/') || trimmed.includes('\\')) return null;
+  if (trimmed === '.' || trimmed === '..') return null;
+  for (let i = 0; i < trimmed.length; i++) {
+    const code = trimmed.charCodeAt(i);
+    if (code < 32 || code === 127) return null;
+  }
+  if (trimmed.length > MKDIR_NAME_MAX_LEN) return null;
+  const basename = nodePath.basename(trimmed);
+  if (basename !== trimmed) return null;
+  return basename;
+}
+
+function joinRootRelative(parentRel: string, name: string): string {
+  if (!parentRel || parentRel === '.') return name;
+  return `${parentRel}/${name}`;
+}
+
+function suggestAvailableName(dirAbsolutePath: string, originalName: string): string {
+  const ext = nodePath.extname(originalName);
+  const stem = ext ? originalName.slice(0, -ext.length) : originalName;
+  for (let i = 1; i <= 1000; i++) {
+    const candidate = `${stem} (${i})${ext}`;
+    if (!fs.existsSync(nodePath.join(dirAbsolutePath, candidate))) {
+      return candidate;
+    }
+  }
+  return `${stem}-${crypto.randomBytes(4).toString('hex')}${ext}`;
 }


### PR DESCRIPTION
## Summary

Adds two owner-only HTTP endpoints to power a future fs-explorer write UI. Server-only — UI lands in a follow-up PR.

- **`POST /api/fs/upload?root=&path=&filename=&on_conflict=fail|rename|overwrite`** — streams `application/octet-stream` bodies into the target directory, atomic via `.partial` + rename, 25 MB cap, conflict policy with auto-suggested name on 409.
- **`POST /api/fs/mkdir`** — JSON `{ root, path, name }`, creates a single directory level.

Both endpoints:
- gate on `currentUser.role === 'owner'` (403 otherwise)
- reuse `resolveFileTarget` (with `allowMissing: true`) for traversal/symlink guards
- sanitize the basename: reject empty, `.`, `..`, slashes, backslashes, control chars, NUL bytes, length > 255
- broadcast `fs:invalidate` on success so connected clients can refresh

## Why server-first

Opens a write surface on the filesystem — landing the hardened endpoints + tests first, then wiring the UI (drag-and-drop, paste-to-upload, `+ Add` button, conflict dialog) in a separate PR where the review can focus on UX without re-litigating the security model.

## Notable implementation detail

First iteration treated the `req.on('close')` event as an error, which racy-fired before `writeStream.end(cb)` finalized on keep-alive connections, breaking happy-path uploads. Fixed by tracking `endReceived` and only treating `'close'` as anomalous when end hasn't been received (`filesystem.ts:357`).

## Test plan

- [x] `npm test` — 469/469 passing (cli 11 + core 327 + server 84 incl. 20 new + web 47)
- [x] `npm run build` — clean
- [x] New `api-filesystem-write.test.ts` covers: 403 non-owner, 400 traversal/NUL/empty/invalid-policy, 413 oversize (with temp `.partial` cleanup verified), 409 conflict (fail/dir-overwrite) with `suggestedName`, 201 rename + overwrite paths, mkdir happy/error paths
- [ ] Manual smoke once UI follow-up lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)