### PR TITLE
Wire fs.invalidated broadcast so other clients refresh after writes

### DIFF
--- a/packages/core/src/protocol/events.ts
+++ b/packages/core/src/protocol/events.ts
@@ -167,6 +167,13 @@ export interface ErrorEvent {
   message: string;
 }
 
+export interface FsInvalidatedEvent {
+  type: 'fs.invalidated';
+  rootId: string;
+  /** Directory path relative to the root; '' for the root itself. */
+  path: string;
+}
+
 export type ServerEvent =
   | TopicHistoryEvent
   | MessageCreatedEvent
@@ -187,6 +194,7 @@ export type ServerEvent =
   | PresenceChangedEvent
   | ArtifactCreatedEvent
   | ArtifactUpdatedEvent
+  | FsInvalidatedEvent
   | ErrorEvent;
 
 // ── Client → Server events ──

--- a/packages/server/src/http/api/filesystem.ts
+++ b/packages/server/src/http/api/filesystem.ts
@@ -400,8 +400,8 @@ export function handleFilesystemRoutes(routeCtx: ApiRouteContext): boolean {
         settled = true;
         try {
           ctx.broadcastGlobal({
-            kind: 'fs:invalidate',
-            root: rootId,
+            type: 'fs.invalidated',
+            rootId,
             path: parentTarget.relativePath === '.' ? '' : parentTarget.relativePath,
           });
         } catch { /* broadcasting must never break the response */ }
@@ -497,8 +497,8 @@ export function handleFilesystemRoutes(routeCtx: ApiRouteContext): boolean {
       }
       try {
         ctx.broadcastGlobal({
-          kind: 'fs:invalidate',
-          root: rootId,
+          type: 'fs.invalidated',
+          rootId,
           path: parentTarget.relativePath === '.' ? '' : parentTarget.relativePath,
         });
       } catch { /* broadcasting must never break the response */ }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -560,6 +560,14 @@ export function App() {
           setPresence((event as any).presence);
           break;
 
+        case 'fs.invalidated':
+          window.dispatchEvent(
+            new CustomEvent('teepee:fs-invalidated', {
+              detail: { rootId: event.rootId, path: event.path },
+            }),
+          );
+          break;
+
       }
     },
     [activeTopicId, updateTopicInputRequests, updateTopicJobs]

--- a/packages/web/src/components/filesystem-explorer.test.tsx
+++ b/packages/web/src/components/filesystem-explorer.test.tsx
@@ -227,6 +227,28 @@ describe('FilesystemExplorer — conflict dialog', () => {
   });
 });
 
+describe('FilesystemExplorer — fs.invalidated broadcast', () => {
+  it('refetches a directory when teepee:fs-invalidated fires for it', async () => {
+    const calls = installFetchMock(defaultResponder);
+    renderExplorer();
+    await waitFor(() => expect(screen.getByText('workspace')).toBeTruthy());
+
+    const initialEntriesCalls = calls.filter((c) => c.url.startsWith('/api/fs/entries')).length;
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('teepee:fs-invalidated', {
+          detail: { rootId: 'workspace', path: '' },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      const after = calls.filter((c) => c.url.startsWith('/api/fs/entries')).length;
+      expect(after).toBeGreaterThan(initialEntriesCalls);
+    });
+  });
+});
+
 describe('FilesystemExplorer — new folder', () => {
   it('creates a new folder via POST /api/fs/mkdir and notifies on success', async () => {
     const calls = installFetchMock((url, init) => {

--- a/packages/web/src/hooks/useFilesystemTree.ts
+++ b/packages/web/src/hooks/useFilesystemTree.ts
@@ -28,6 +28,8 @@ export function nodeKey(rootId: string, path: string): string {
   return `${rootId}:${path}`;
 }
 
+export const FS_INVALIDATED_EVENT = 'teepee:fs-invalidated';
+
 export function useFilesystemTree() {
   const [roots, setRoots] = useState<FilesystemRootInfo[]>([]);
   const [rootsLoading, setRootsLoading] = useState(true);
@@ -127,6 +129,17 @@ export function useFilesystemTree() {
     },
     [loadChildren]
   );
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ rootId: string; path: string }>).detail;
+      if (!detail || typeof detail.rootId !== 'string') return;
+      const normalizedPath = typeof detail.path === 'string' ? detail.path : '';
+      loadChildren(detail.rootId, normalizedPath || '.', true);
+    };
+    window.addEventListener(FS_INVALIDATED_EVENT, handler);
+    return () => window.removeEventListener(FS_INVALIDATED_EVENT, handler);
+  }, [loadChildren]);
 
   const isExpanded = useCallback(
     (rootId: string, path: string) => expandedKeys.has(nodeKey(rootId, path)),


### PR DESCRIPTION
## Summary

Closes the SOTA gap left from #12 + #13: the upload/mkdir endpoints already broadcast on success, but the event shape was inconsistent (`kind: 'fs:invalidate'` vs. the rest of the protocol which uses `type: 'something.dotted'`) and no client was listening, so multi-tab / multi-client coherence on uploads was lost.

- **core/protocol**: adds `FsInvalidatedEvent` to the `ServerEvent` union with `{ type: 'fs.invalidated', rootId, path }`
- **server**: renames both broadcast sites in `filesystem.ts` to emit the typed event
- **web/App.tsx**: dispatches a `teepee:fs-invalidated` window event when the WS event arrives
- **web/useFilesystemTree**: subscribes to that window event and refetches the affected directory

## Why a window-event hop instead of prop drilling

`useFilesystemTree` is owned by `FilesystemExplorer`, which only mounts when the user is on the Files tab. A `window` event bus lets `App.tsx` fire the signal without conditionally importing the explorer or threading a ref through everything else. The listener only exists while the panel is mounted; if a user is elsewhere when the event fires, they get fresh data on the next mount anyway via the existing `refreshRoots`/`loadChildren` cycle — no stale tree.

## Test plan

- [x] `npm test` — 476/476 (cli 11 + core 327 + server 84 + web 54 incl. 1 new)
- [x] `npm run build` — clean
- [x] New web test: dispatches `teepee:fs-invalidated` and asserts a fresh `GET /api/fs/entries` follows
- [ ] Manual two-tab smoke: upload in tab A → tab B's tree refreshes the affected dir without user action

🤖 Generated with [Claude Code](https://claude.com/claude-code)