### PR TITLE
Release 0.3.3: host filesystem root off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This project now keeps a forward-maintained release history here and on GitHub Releases.
 
+## v0.3.3
+
+Breaking change
+
+- The implicit `host` filesystem root (kind: `host`, path: `/`) is no longer registered by default. The owner — like every other role — now only sees the `workspace` root unless `filesystem.allow_host_root: true` is set in `.teepee/config.yaml`. Non-owner roles were already gated by the `files.host.access` capability; this change closes the gap for owners and makes secure-by-default the new normal. Re-enable with a single line if your workflow needs agents to browse outside the workspace.
+
+Other notes
+
+- Server startup now prints `Host fs: disabled (set filesystem.allow_host_root: true to enable)` when the flag is off, so operators can discover the override without grepping the config schema.
+- The v2 config migration preserves `filesystem.allow_host_root` while still stripping the legacy `filesystem.roots` field — opting in does not get clobbered on a restart.
+
 ## v0.3.2
 
 Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teepee",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teepee",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -6468,11 +6468,11 @@
     },
     "packages/cli": {
       "name": "teepee-cli",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
-        "teepee-core": "^0.3.2",
-        "teepee-server": "^0.3.2"
+        "teepee-core": "^0.3.3",
+        "teepee-server": "^0.3.3"
       },
       "bin": {
         "teepee": "dist/index.js",
@@ -6817,7 +6817,7 @@
     },
     "packages/core": {
       "name": "teepee-core",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^11.0.0",
@@ -6831,10 +6831,10 @@
     },
     "packages/server": {
       "name": "teepee-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "dependencies": {
-        "teepee-core": "^0.3.2",
+        "teepee-core": "^0.3.3",
         "ws": "^8.17.0"
       },
       "devDependencies": {
@@ -6846,7 +6846,7 @@
     },
     "packages/web": {
       "name": "@teepee/web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "highlight.js": "^11.11.1",
         "react": "^19.0.0",
@@ -6854,7 +6854,7 @@
         "react-markdown": "^9.0.0",
         "rehype-highlight": "^7.0.0",
         "remark-gfm": "^4.0.1",
-        "teepee-core": "^0.3.2"
+        "teepee-core": "^0.3.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepee",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Teepee runs a team of AI agents — coordinating them in realtime.",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepee-cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "CLI for Teepee, a self-hosted workspace to coordinate AI agents in realtime.",
   "bin": {
     "teepee": "dist/index.js",
@@ -15,8 +15,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "teepee-core": "^0.3.2",
-    "teepee-server": "^0.3.2"
+    "teepee-core": "^0.3.3",
+    "teepee-server": "^0.3.3"
   },
   "homepage": "https://teepee.org",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepee-core",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Core orchestration and storage primitives for Teepee.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/src/config-v2.test.ts
+++ b/packages/core/src/config-v2.test.ts
@@ -182,4 +182,81 @@ roles:
     expect(result.output).not.toContain('filesystem:');
     expect(result.output).toContain('files.workspace.access');
   });
+
+  it('preserves filesystem.allow_host_root while stripping legacy filesystem.roots', () => {
+    const file = tmpConfig(`
+version: 2
+mode: shared
+teepee:
+  name: test
+filesystem:
+  allow_host_root: true
+  roots:
+    - id: workspace
+      kind: workspace
+      path: .
+providers:
+  p:
+    command: "echo"
+agents:
+  coder:
+    provider: p
+roles:
+  owner:
+    superuser: true
+  collaborator:
+    capabilities:
+      - files.workspace.access
+      - messages.post
+    agents:
+      coder: readwrite
+  observer:
+    capabilities:
+      - files.workspace.access
+    agents: {}
+`);
+
+    const result = migrateConfigFileToV2(file);
+    expect(result.migrated).toBe(true);
+    expect(result.output).toContain('allow_host_root: true');
+    expect(result.output).not.toContain('roots:');
+
+    fs.writeFileSync(file, result.output, 'utf-8');
+    const config = loadConfig(file);
+    expect(config.filesystem.allow_host_root).toBe(true);
+    expect(config.filesystem.roots.map((r) => r.id)).toEqual(['workspace', 'host']);
+  });
+
+  it('does not re-migrate a config whose filesystem only carries allow_host_root', () => {
+    const file = tmpConfig(`
+version: 2
+mode: shared
+teepee:
+  name: test
+filesystem:
+  allow_host_root: true
+providers:
+  p:
+    command: "echo"
+agents:
+  coder:
+    provider: p
+roles:
+  owner:
+    superuser: true
+  collaborator:
+    capabilities:
+      - files.workspace.access
+      - messages.post
+    agents:
+      coder: readwrite
+  observer:
+    capabilities:
+      - files.workspace.access
+    agents: {}
+`);
+
+    const result = migrateConfigFileToV2(file);
+    expect(result.migrated).toBe(false);
+  });
 });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -646,6 +646,58 @@ agents:
     expect(config.security.sandbox.private_tmp).toBe(true);
     expect(config.security.sandbox.forward_env).toEqual([]);
   });
+
+  it('omits the host filesystem root by default (allow_host_root defaults to false)', () => {
+    const file = tmpConfig(`
+teepee:
+  name: hostroot-default
+providers:
+  p:
+    command: "echo"
+agents:
+  a:
+    provider: p
+`);
+    const config = loadConfig(file);
+    expect(config.filesystem.allow_host_root).toBe(false);
+    expect(config.filesystem.roots.map((r) => r.id)).toEqual(['workspace']);
+  });
+
+  it('registers the host filesystem root when filesystem.allow_host_root is true', () => {
+    const file = tmpConfig(`
+teepee:
+  name: hostroot-on
+filesystem:
+  allow_host_root: true
+providers:
+  p:
+    command: "echo"
+agents:
+  a:
+    provider: p
+`);
+    const config = loadConfig(file);
+    expect(config.filesystem.allow_host_root).toBe(true);
+    expect(config.filesystem.roots.map((r) => r.id)).toEqual(['workspace', 'host']);
+  });
+
+  it('treats non-boolean allow_host_root as the secure default (false)', () => {
+    const file = tmpConfig(`
+teepee:
+  name: hostroot-bogus
+filesystem:
+  allow_host_root: "yes"
+providers:
+  p:
+    command: "echo"
+agents:
+  a:
+    provider: p
+`);
+    const config = loadConfig(file);
+    expect(config.filesystem.allow_host_root).toBe(false);
+    expect(config.filesystem.roots.map((r) => r.id)).toEqual(['workspace']);
+  });
 });
 
 describe('resolveTimeout', () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -100,6 +100,12 @@ export interface FilesystemRootConfig {
 }
 
 export interface FilesystemConfig {
+  /**
+   * When false (the default), the implicit `host` root (kind: 'host', path: '/')
+   * is not registered, even for the owner. Set to true in `.teepee/config.yaml`
+   * under `filesystem.allow_host_root` to opt in.
+   */
+  allow_host_root: boolean;
   roots: FilesystemRootConfig[];
 }
 
@@ -180,13 +186,24 @@ const DEFAULT_LIMITS: LimitsConfig = {
   max_total_jobs_per_chain: 10,
 };
 
-function buildFilesystemConfig(projectRoot: string): FilesystemConfig {
-  return {
-    roots: [
-      { id: 'workspace', kind: 'workspace', path: '.', resolvedPath: path.resolve(projectRoot, '.') },
-      { id: 'host', kind: 'host', path: '/', resolvedPath: '/' },
-    ],
-  };
+function parseAllowHostRoot(rawFilesystem: unknown): boolean {
+  if (typeof rawFilesystem !== 'object' || rawFilesystem === null) return false;
+  const value = (rawFilesystem as Record<string, unknown>).allow_host_root;
+  if (typeof value === 'boolean') return value;
+  return false;
+}
+
+function buildFilesystemConfig(
+  projectRoot: string,
+  allowHostRoot: boolean
+): FilesystemConfig {
+  const roots: FilesystemRootConfig[] = [
+    { id: 'workspace', kind: 'workspace', path: '.', resolvedPath: path.resolve(projectRoot, '.') },
+  ];
+  if (allowHostRoot) {
+    roots.push({ id: 'host', kind: 'host', path: '/', resolvedPath: '/' });
+  }
+  return { allow_host_root: allowHostRoot, roots };
 }
 
 const DEFAULT_SECURITY: SecurityConfig = {
@@ -265,7 +282,7 @@ export function loadConfig(configPath: string): TeepeeConfig {
     providers: {},
     agents: {},
     roles: {},
-    filesystem: buildFilesystemConfig(projectRoot),
+    filesystem: buildFilesystemConfig(projectRoot, parseAllowHostRoot(parsed.filesystem)),
     limits: { ...DEFAULT_LIMITS, ...parsed.limits },
     security: buildSecurityConfig(parsed.security),
   };
@@ -872,7 +889,18 @@ function buildMigratedConfigDocument(parsed: any, config: TeepeeConfig): Record<
   const next = JSON.parse(JSON.stringify(parsed)) as Record<string, unknown>;
   next.version = 2;
   next.roles = serializeRolesForV2(config.roles);
-  delete next.filesystem;
+
+  // Strip legacy filesystem.roots; preserve filesystem.allow_host_root when present.
+  const rawFilesystem = next.filesystem;
+  if (typeof rawFilesystem === 'object' && rawFilesystem !== null && !Array.isArray(rawFilesystem)) {
+    const fs = rawFilesystem as Record<string, unknown>;
+    delete fs.roots;
+    if (Object.keys(fs).length === 0) {
+      delete next.filesystem;
+    }
+  } else {
+    delete next.filesystem;
+  }
 
   const rawAgents = typeof next.agents === 'object' && next.agents !== null && !Array.isArray(next.agents)
     ? next.agents as Record<string, Record<string, unknown>>
@@ -892,7 +920,12 @@ function needsV2ConfigNormalization(parsed: any): boolean {
     return false;
   }
 
-  if (parsed.filesystem !== undefined) {
+  if (
+    typeof parsed.filesystem === 'object' &&
+    parsed.filesystem !== null &&
+    !Array.isArray(parsed.filesystem) &&
+    (parsed.filesystem as Record<string, unknown>).roots !== undefined
+  ) {
     return true;
   }
 

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -26,6 +26,7 @@ export function createTestConfig(overrides: Partial<TeepeeConfig> = {}): TeepeeC
       owner: { superuser: true, agents: { coder: 'trusted' } },
     },
     filesystem: {
+      allow_host_root: false,
       roots: [{ id: 'workspace', kind: 'workspace', path: '.', resolvedPath: process.cwd() }],
     },
     limits: {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teepee-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "HTTP and WebSocket server for Teepee.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "teepee-core": "^0.3.2",
+    "teepee-core": "^0.3.3",
     "ws": "^8.17.0"
   },
   "devDependencies": {

--- a/packages/server/src/api-filesystem.test.ts
+++ b/packages/server/src/api-filesystem.test.ts
@@ -82,6 +82,8 @@ version: 2
 mode: shared
 teepee:
   name: fs-api-test
+filesystem:
+  allow_host_root: true
 providers:
   echo:
     command: "cat"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -268,6 +268,9 @@ export function startServer(
     console.log(`\n  Project: ${config.teepee.name}`);
     console.log(`  Mode:    ${config.mode}`);
     console.log(`  Agents:  ${Object.keys(config.agents).join(', ')}`);
+    if (!config.filesystem.allow_host_root) {
+      console.log(`  Host fs: disabled (set filesystem.allow_host_root: true to enable)`);
+    }
     console.log(`\n  Open the owner login link to get started.`);
     console.log(`  The secret changes on every restart.\n`);
   });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@teepee/web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {
@@ -17,7 +17,7 @@
     "react-markdown": "^9.0.0",
     "rehype-highlight": "^7.0.0",
     "remark-gfm": "^4.0.1",
-    "teepee-core": "^0.3.2"
+    "teepee-core": "^0.3.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",

--- a/releases/v0.3.3.md
+++ b/releases/v0.3.3.md
@@ -1,0 +1,24 @@
+# Teepee v0.3.3
+
+Teepee `v0.3.3` flips the host filesystem root to **off by default**. Even the owner now only sees the project's `workspace/` unless `.teepee/config.yaml` explicitly opts in — making `mode: shared` deployments harder to misconfigure into broad host access.
+
+## Highlights
+
+- **Breaking**: the implicit `host` filesystem root (`kind: host`, `path: /`) is no longer registered automatically. To restore the previous behavior, add this to `.teepee/config.yaml`:
+
+  ```yaml
+  filesystem:
+    allow_host_root: true
+  ```
+
+  Non-owner roles (`collaborator`, `observer`, custom roles) were already gated by the `files.host.access` capability and never saw this root in practice; the change closes the loophole for owners.
+
+- The v2 config migration now preserves `filesystem.allow_host_root` while stripping the legacy `filesystem.roots` field, so opting in survives every restart.
+
+- Server startup logs `Host fs: disabled (set filesystem.allow_host_root: true to enable)` when the flag is off — making the override discoverable without reading the schema.
+
+## Notes
+
+- Patch release on top of `v0.3.1`/`v0.3.2`: same publish targets (`teepee-core`, `teepee-server`, `teepee-cli`), no schema migration that touches user data.
+- Existing deployments that relied on the owner being able to browse the host filesystem from the Files sidebar will see only `workspace/` after upgrading until the flag is set. The fix is one YAML line.
+- Tests in `packages/core/src/config.test.ts` and `packages/core/src/config-v2.test.ts` cover both the off-by-default behavior and the opt-in path, including migration preservation.


### PR DESCRIPTION
## Summary

Hardens the default deployment by removing the implicit `host` filesystem root (`kind: host`, `path: /`). Even the owner now sees only `workspace/` unless `.teepee/config.yaml` explicitly opts in:

```yaml
filesystem:
  allow_host_root: true
```

## Why

`mode: shared` deployments inherited owner-visible full-host access without an explicit decision — the owner role is hard-coded `superuser: true`, which grants `files.host.access`, which gave the Files sidebar the entire `/` to browse. Non-owner roles were already gated by the capability and saw no change. Closing the gap for owners makes `mode: shared` secure-by-default and keeps the override one line away when an agent legitimately needs to read outside the workspace.

## Changes

- **core**: `FilesystemConfig.allow_host_root` (default `false`). `buildFilesystemConfig` only registers the host root when the flag is true; `loadConfig` parses the flag via `parseAllowHostRoot`.
- **migration**: `buildMigratedConfigDocument` now deletes only `filesystem.roots` (the legacy v1 field) and preserves `filesystem.allow_host_root`. `needsV2ConfigNormalization` only triggers when `filesystem.roots` exists, so a config carrying just `allow_host_root: true` does not loop through migration on every restart.
- **server**: startup log adds `Host fs: disabled (set filesystem.allow_host_root: true to enable)` when the flag is off.
- **tests**: covers default off, explicit on, bogus value (`"yes"`) treated as off, migration that preserves `allow_host_root: true` while stripping `roots`, and the no-migration loop when only the flag is present.

## Breaking

For owners on existing `v0.3.x` deployments that relied on the host root being visible, the Files sidebar will only show `workspace/` after upgrade. Fix is one YAML line.

## Test plan

- [x] `npm test` — 481/481 (cli 11 + core 332 incl. 5 new + server 84 + web 54)
- [x] `npm run build` — clean
- [x] `npm run release:pack` — tarballs match (`teepee-core@0.3.3`, `teepee-server@0.3.3`, `teepee-cli@0.3.3`)
- [ ] Manual: on a deploy with `filesystem.allow_host_root: false` (default), owner login → Files sidebar shows only `workspace`. With the flag on, both roots appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)